### PR TITLE
Add trading service skeleton

### DIFF
--- a/trading-service/.editorconfig
+++ b/trading-service/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/trading-service/.gitignore
+++ b/trading-service/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.notebooks/

--- a/trading-service/README.md
+++ b/trading-service/README.md
@@ -1,0 +1,3 @@
+# Trading Service
+
+This package provides a sample layout for an event driven trading service. It demonstrates the architecture used for ingestion, feature engineering, model inference and trade execution.

--- a/trading-service/configs/dev.yaml
+++ b/trading-service/configs/dev.yaml
@@ -1,0 +1,1 @@
+log_level: DEBUG

--- a/trading-service/configs/prod.yaml
+++ b/trading-service/configs/prod.yaml
@@ -1,0 +1,1 @@
+log_level: INFO

--- a/trading-service/docker/Dockerfile
+++ b/trading-service/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["bash", "scripts/run_gateway.sh"]

--- a/trading-service/notebooks/research.ipynb
+++ b/trading-service/notebooks/research.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}

--- a/trading-service/pyproject.toml
+++ b/trading-service/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "trading_service"
+version = "0.1.0"
+description = "Event driven trading service"
+authors = ["Example <dev@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "^0.110.0"
+pydantic = "^2.1.1"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.2"
+pytest-asyncio = "^0.21.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/trading-service/requirements.txt
+++ b/trading-service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+pydantic==2.1.1

--- a/trading-service/scripts/run_gateway.sh
+++ b/trading-service/scripts/run_gateway.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m trading_service.ingestion.ingestion_gateway

--- a/trading-service/src/tests/__init__.py
+++ b/trading-service/src/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for trading service."""

--- a/trading-service/src/tests/test_ingestion.py
+++ b/trading-service/src/tests/test_ingestion.py
@@ -1,0 +1,9 @@
+import asyncio
+
+from trading_service.ingestion.ingestion_gateway import main
+
+
+def test_ingestion_gateway(capsys):
+    main()
+    captured = capsys.readouterr()
+    assert "Starting ingestion gateway" in captured.out

--- a/trading-service/src/tests/test_orderbook.py
+++ b/trading-service/src/tests/test_orderbook.py
@@ -1,0 +1,6 @@
+from trading_service.decision.trade_logic import decide
+
+
+def test_decide():
+    signal = decide([1, 2, 3])
+    assert signal == "BUY"

--- a/trading-service/src/trading_service/__init__.py
+++ b/trading-service/src/trading_service/__init__.py
@@ -1,0 +1,1 @@
+"""Trading service package."""

--- a/trading-service/src/trading_service/api/__init__.py
+++ b/trading-service/src/trading_service/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI interface."""

--- a/trading-service/src/trading_service/api/rest.py
+++ b/trading-service/src/trading_service/api/rest.py
@@ -1,0 +1,10 @@
+"""REST API endpoints."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/ping")
+async def ping() -> dict:
+    return {"status": "ok"}

--- a/trading-service/src/trading_service/decision/__init__.py
+++ b/trading-service/src/trading_service/decision/__init__.py
@@ -1,0 +1,1 @@
+"""Trading decision logic."""

--- a/trading-service/src/trading_service/decision/trade_logic.py
+++ b/trading-service/src/trading_service/decision/trade_logic.py
@@ -1,0 +1,8 @@
+"""Trade decision module."""
+
+from trading_service.models.predictor import predict
+
+
+def decide(orderbook: list) -> str:
+    features = orderbook
+    return predict(features)

--- a/trading-service/src/trading_service/execution/__init__.py
+++ b/trading-service/src/trading_service/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Execution adapters."""

--- a/trading-service/src/trading_service/execution/execution_adapter.py
+++ b/trading-service/src/trading_service/execution/execution_adapter.py
@@ -1,0 +1,5 @@
+"""Execution adapter stub."""
+
+
+def send_order(signal: str) -> None:
+    print(f"Executing order: {signal}")

--- a/trading-service/src/trading_service/features/__init__.py
+++ b/trading-service/src/trading_service/features/__init__.py
@@ -1,0 +1,1 @@
+"""Feature pipeline."""

--- a/trading-service/src/trading_service/features/feature_pipe.py
+++ b/trading-service/src/trading_service/features/feature_pipe.py
@@ -1,0 +1,6 @@
+"""Feature processing stub."""
+
+
+def build_features(data: list) -> list:
+    """Pretend to build features from raw data."""
+    return data

--- a/trading-service/src/trading_service/ingestion/__init__.py
+++ b/trading-service/src/trading_service/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Ingestion components."""

--- a/trading-service/src/trading_service/ingestion/ingestion_gateway.py
+++ b/trading-service/src/trading_service/ingestion/ingestion_gateway.py
@@ -1,0 +1,9 @@
+"""Ingestion gateway stub."""
+
+
+def main() -> None:
+    print("Starting ingestion gateway")
+
+
+if __name__ == "__main__":
+    main()

--- a/trading-service/src/trading_service/models/__init__.py
+++ b/trading-service/src/trading_service/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model related modules."""

--- a/trading-service/src/trading_service/models/predictor.py
+++ b/trading-service/src/trading_service/models/predictor.py
@@ -1,0 +1,6 @@
+"""Model predictor stub."""
+
+
+def predict(features: list) -> str:
+    """Return dummy trade signal based on features."""
+    return "BUY"

--- a/trading-service/src/trading_service/monitoring/__init__.py
+++ b/trading-service/src/trading_service/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring tools."""

--- a/trading-service/src/trading_service/monitoring/metrics.py
+++ b/trading-service/src/trading_service/monitoring/metrics.py
@@ -1,0 +1,5 @@
+"""Metrics collection stub."""
+
+
+def record(metric: str, value: float) -> None:
+    print(f"{metric}: {value}")

--- a/trading-service/src/trading_service/persistence/__init__.py
+++ b/trading-service/src/trading_service/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Database layer."""

--- a/trading-service/src/trading_service/persistence/db.py
+++ b/trading-service/src/trading_service/persistence/db.py
@@ -1,0 +1,5 @@
+"""DB connection stub."""
+
+
+def get_connection() -> None:
+    print("Connecting to DB")

--- a/trading-service/src/trading_service/persistence/schema.sql
+++ b/trading-service/src/trading_service/persistence/schema.sql
@@ -1,0 +1,1 @@
+-- SQL schema placeholder

--- a/trading-service/src/trading_service/risk/__init__.py
+++ b/trading-service/src/trading_service/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk management."""

--- a/trading-service/src/trading_service/risk/risk_manager.py
+++ b/trading-service/src/trading_service/risk/risk_manager.py
@@ -1,0 +1,5 @@
+"""Risk management stub."""
+
+
+def check_risk(signal: str) -> bool:
+    return True


### PR DESCRIPTION
## Summary
- scaffold a trading-service project
- add API, ingestion and decision stubs
- configure Poetry, Dockerfile and scripts
- provide example tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c7698b688332bed75d15923eef4c