### PR TITLE
Add orjson and websockets dependencies

### DIFF
--- a/trading-service/requirements.txt
+++ b/trading-service/requirements.txt
@@ -1,2 +1,5 @@
 fastapi==0.110.0
 pydantic==2.1.1
+
+orjson
+websockets


### PR DESCRIPTION
## Summary
- include `orjson` and `websockets` in trading-service requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847543d88c48332bb359526d888d0de